### PR TITLE
Update FloatMenu.xml

### DIFF
--- a/Keyed/FloatMenu.xml
+++ b/Keyed/FloatMenu.xml
@@ -99,7 +99,7 @@
   <CannotTrade>トレードできない</CannotTrade>
 
 <!-- Specific thing interactions -->
-    <EnterCryptosleepPod>冬眠カプセルに入る</EnterCryptosleepPod>
+    <EnterCryptosleepCasket>冬眠カプセルに入る</EnterCryptosleepCasket>
     <OpenCryptosleepCasket>冬眠カプセルを開ける</OpenCryptosleepCasket>
 
 


### PR DESCRIPTION
入植者に宇宙船用を含む冬眠カプセルに入る指示をする時のテキストが翻訳されていなかったので修正しました。
EnterCryptosleepPodの代わりにEnterCryptosleepCasketが使用されているようです。
