### PR TITLE
trauma savantについて

### DIFF
--- a/DefInjected/HediffDefs/Hediffs_Local_Misc.xml
+++ b/DefInjected/HediffDefs/Hediffs_Local_Misc.xml
@@ -1,12 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
-
-    <TraumaSavant.label>トラウマサヴァン</TraumaSavant.label>
-
-    <ChemicalDamageBrain.label>大脳変性(化学的)</ChemicalDamageBrain.label>
-
-    <ChemicalDamageKidney.label>腎臓(科学的)</ChemicalDamageKidney.label>
-
-    <Cirrhosis.label>肝硬変</Cirrhosis.label>
-
+  <TraumaSavant.label>後天性サヴァン症</TraumaSavant.label>
+  <ChemicalDamageBrain.label>大脳変性(化学的)</ChemicalDamageBrain.label>
+  <ChemicalDamageKidney.label>腎臓(科学的)</ChemicalDamageKidney.label>
+  <Cirrhosis.label>肝硬変</Cirrhosis.label>
 </LanguageData>

--- a/DefInjected/HediffGiverSetDef/HediffGiverSets.xml
+++ b/DefInjected/HediffGiverSetDef/HediffGiverSets.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+  <OrganicStandard.hediffGivers.4.letterLabel>後天性サヴァン</OrganicStandard.hediffGivers.4.letterLabel>
+  <OrganicStandard.hediffGivers.4.letter>NAMEの脳の損傷はHIMに奇妙な天才じみた能力を発達させた。</OrganicStandard.hediffGivers.4.letter>
+</LanguageData>

--- a/DefInjected/HediffGiverSetDef/HediffGiverSets.xml
+++ b/DefInjected/HediffGiverSetDef/HediffGiverSets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
-  <OrganicStandard.hediffGivers.4.letterLabel>後天性サヴァン</OrganicStandard.hediffGivers.4.letterLabel>
+  <OrganicStandard.hediffGivers.4.letterLabel>後天性サヴァン症</OrganicStandard.hediffGivers.4.letterLabel>
   <OrganicStandard.hediffGivers.4.letter>NAMEの脳の損傷はHIMに奇妙な天才じみた能力を発達させた。</OrganicStandard.hediffGivers.4.letter>
 </LanguageData>

--- a/DefInjected/HediffGiverSetDef/HediffGiverSets.xml
+++ b/DefInjected/HediffGiverSetDef/HediffGiverSets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
   <OrganicStandard.hediffGivers.4.letterLabel>後天性サヴァン症</OrganicStandard.hediffGivers.4.letterLabel>
-  <OrganicStandard.hediffGivers.4.letter>NAMEの脳の損傷はHIMに奇妙な天才じみた能力を発達させた。</OrganicStandard.hediffGivers.4.letter>
+  <OrganicStandard.hediffGivers.4.letter>NAMEの脳の損傷はHIMに奇妙な天才じみた能力を発達させました。</OrganicStandard.hediffGivers.4.letter>
 </LanguageData>


### PR DESCRIPTION
他言語の翻訳フォルダ覗いた際に見つけました。
トラウマは日本では精神的外傷として使われることが多く、
また説明の通り脳への外傷によってサヴァン症候群が発現したのを後天性サヴァン症候群と書くことが多いのでそれに準じました。